### PR TITLE
Fixing issues with untradeable market items

### DIFF
--- a/spec/client_spec/market_spec.cr
+++ b/spec/client_spec/market_spec.cr
@@ -45,5 +45,10 @@ describe XIVAPI::Client do
       client = XIVAPI::Client.new
       client.market_search_categories
     end
+
+    it "tests against arthan's found error" do
+      client = XIVAPI::Client.new
+      client.market(item_id: 20770_u64, server: "Lich")
+    end
   end
 end

--- a/spec/client_spec/market_spec.cr
+++ b/spec/client_spec/market_spec.cr
@@ -45,10 +45,5 @@ describe XIVAPI::Client do
       client = XIVAPI::Client.new
       client.market_search_categories
     end
-
-    it "tests against arthan's found error" do
-      client = XIVAPI::Client.new
-      client.market(item_id: 20770_u64, server: "Lich")
-    end
   end
 end

--- a/spec/regression_spec.cr
+++ b/spec/regression_spec.cr
@@ -1,0 +1,14 @@
+require "./spec_helper"
+
+# Special test suite for found bugs to make sure we don't regress
+describe "Regression Tests" do
+  it "can parse untradeable items" do
+    client = XIVAPI::Client.new
+    client.market(item_id: 20770_u64, server: "Lich")
+  end
+
+  it "correctly searches for 'Iron Claw Hammer'" do
+    client = XIVAPI::Client.new
+    client.search(string: "Iron Claw Hammer", indexes: ["Item"], string_algo: "match")
+  end
+end

--- a/src/converters.cr
+++ b/src/converters.cr
@@ -1,0 +1,23 @@
+module XIVAPI
+  # A module containing modules that convert to and from JSON
+  module Converters
+    module NilableEpochConverter
+      def self.from_json(value : JSON::PullParser) : Time?
+        time = value.read_int_or_null
+        if !time.nil?
+          return Time.unix(time)
+        else
+          return nil
+        end
+      end
+
+      def self.to_json(value : Time?, io : IO)
+        if value.nil?
+          io << value
+        else
+          io << value.unix
+        end
+      end
+    end
+  end
+end

--- a/src/dataclasses/market/market_item.cr
+++ b/src/dataclasses/market/market_item.cr
@@ -4,6 +4,25 @@ require "./item_history"
 require "./market_entry"
 
 module XIVAPI
+  module NilableEpochConverter
+    def self.from_json(value : JSON::PullParser) : Time?
+      time = value.read_int_or_null
+      if !time.nil?
+        return Time.unix(time)
+      else
+        return nil
+      end
+    end
+
+    def self.to_json(value : Time?, io : IO)
+      if value.nil?
+        io << value
+      else
+        io << value.unix
+      end
+    end
+  end
+
   module Dataclasses
     # Dataclass representing an item on the Market Board.
     class MarketItem
@@ -13,11 +32,11 @@ module XIVAPI
         id: {type: String, key: "ID"},
         item: {type: Item, key: "Item"},
         item_id: {type: UInt64, key: "ItemID"},
-        lodestone_id: {type: String, key: "LodestoneID"},
+        lodestone_id: {type: String?, key: "LodestoneID"},
         prices: {type: Array(MarketEntry), key: "Prices"},
         server: {type: UInt64, key: "Server"},
-        update_priority: {type: UInt64, key: "UpdatePriority"},
-        updated: {type: Time, key: "Updated", converter: Time::EpochConverter},
+        update_priority: {type: UInt64?, key: "UpdatePriority"},
+        updated: {type: Time?, key: "Updated", converter: NilableEpochConverter},
       )
       # An Array of `ItemHistory` classs representing the old sale values of the Item.
       getter history

--- a/src/dataclasses/market/market_item.cr
+++ b/src/dataclasses/market/market_item.cr
@@ -2,27 +2,9 @@ require "json"
 require "./item"
 require "./item_history"
 require "./market_entry"
+require "../../converters"
 
 module XIVAPI
-  module NilableEpochConverter
-    def self.from_json(value : JSON::PullParser) : Time?
-      time = value.read_int_or_null
-      if !time.nil?
-        return Time.unix(time)
-      else
-        return nil
-      end
-    end
-
-    def self.to_json(value : Time?, io : IO)
-      if value.nil?
-        io << value
-      else
-        io << value.unix
-      end
-    end
-  end
-
   module Dataclasses
     # Dataclass representing an item on the Market Board.
     class MarketItem
@@ -36,7 +18,7 @@ module XIVAPI
         prices: {type: Array(MarketEntry), key: "Prices"},
         server: {type: UInt64, key: "Server"},
         update_priority: {type: UInt64?, key: "UpdatePriority"},
-        updated: {type: Time?, key: "Updated", converter: NilableEpochConverter},
+        updated: {type: Time?, key: "Updated", converter: XIVAPI::Converters::NilableEpochConverter},
       )
       # An Array of `ItemHistory` classs representing the old sale values of the Item.
       getter history

--- a/src/dataclasses/other/search_result.cr
+++ b/src/dataclasses/other/search_result.cr
@@ -13,7 +13,7 @@ module XIVAPI
         url: {type: String, key: "Url"},
         url_type: {type: String, key: "UrlType"},
         datatype: {type: String, key: "_"},
-        score: {type: UInt32, key: "_Score"},
+        score: {type: String, key: "_Score", converter: String::RawConverter},
       )
 
       # The ID of the item returned from the search results.


### PR DESCRIPTION
Some fields are nilable in untradeable market items, including the
updated timestamp, which required a new parser to be written in order
to be handled properly